### PR TITLE
No longer requires recompilation of previews to update the Gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ You can see Swoosh.Gallery in action with the Phoenix app included on `./sample`
 
 1. Run `mix do deps.get, phx.server`
 2. Go to `http://localhost:4000/dev/emails`
+
+
+### Static gallery
+
+You can also generate static HTML files for you Gallery. This is useful when you want to expose the gallery without the need of a server.
+
+```bash
+mix swoosh.gallery.html --gallery Sample.Gallery --path="./_build/gallery"
+
+open _build/gallery/index.html_
+```
+
+
 ## Contributing
 
 1. Download the project.

--- a/lib/mix/tasks/swoosh.gallery.html.ex
+++ b/lib/mix/tasks/swoosh.gallery.html.ex
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Swoosh.Gallery.Html do
       |> Module.concat()
       |> Code.ensure_compiled!()
       |> tap(fn mod ->
-        unless function_exported?(mod, :previews, 0) do
+        unless function_exported?(mod, :get, 0) do
           Mix.raise("""
           The module #{inspect(mod)} is not a valid gallery. Make sure it uses Swoosh.Gallery:
 
@@ -72,13 +72,14 @@ defmodule Mix.Tasks.Swoosh.Gallery.Html do
           """)
         end
       end)
-      |> tap(&ensure_required_functions!(&1.previews))
+      |> then(& &1.get())
+      |> tap(&ensure_required_functions!(&1))
     else
       Mix.raise("No gallery available. Please pass a gallery with the --gallery option")
     end
   end
 
-  defp ensure_required_functions!(previews) when is_list(previews) do
+  defp ensure_required_functions!(%{previews: previews}) when is_list(previews) do
     Enum.each(previews, fn %{email_mfa: {module, _fun, _args}} ->
       ensure_required_functions!(module)
     end)

--- a/lib/swoosh/gallery.ex
+++ b/lib/swoosh/gallery.ex
@@ -134,6 +134,8 @@ defmodule Swoosh.Gallery do
     preview_details = Macro.escape(eval_preview_details(module))
 
     quote do
+      @external_resource List.to_string(unquote(module).module_info(:compile)[:source])
+
       @previews %{
         group: @group_path,
         path: build_preview_path(@group_path, unquote(path)),

--- a/lib/swoosh/gallery.ex
+++ b/lib/swoosh/gallery.ex
@@ -188,7 +188,7 @@ defmodule Swoosh.Gallery do
     end
   end
 
-  # Evaluates a preview. It loads the results of email_mfa and preview_details into the email
+  # Evaluates a preview. It loads the results of email_mfa and details_mfa into the email
   # and preview_details properties respectively.
   @doc false
   @spec eval_preview(%{
@@ -207,7 +207,7 @@ defmodule Swoosh.Gallery do
     Map.put(preview, :email, apply(module, fun, opts))
   end
 
-  # Evaluates preview details. It loads the results of preview_details into the
+  # Evaluates preview details. It loads the results of details_mfa into the
   # preview_details property.
   @doc false
   @spec eval_details(

--- a/lib/swoosh/gallery.ex
+++ b/lib/swoosh/gallery.ex
@@ -92,7 +92,7 @@ defmodule Swoosh.Gallery do
       @group_path nil
 
       def init(opts) do
-        Keyword.put(opts, :gallery, __MODULE__)
+        Keyword.put(opts, :gallery, __MODULE__.get())
       end
 
       def call(conn, opts) do
@@ -106,9 +106,10 @@ defmodule Swoosh.Gallery do
   defmacro __before_compile__(_env) do
     quote do
       @doc false
-      def previews, do: @previews
-
-      def groups, do: @groups
+      def get do
+        previews = eval_details(@previews)
+        %{previews: previews, groups: @groups}
+      end
     end
   end
 

--- a/lib/swoosh/gallery.ex
+++ b/lib/swoosh/gallery.ex
@@ -209,7 +209,7 @@ defmodule Swoosh.Gallery do
   # Evaluates preview details. It loads the results of preview_details into the
   # preview_details property.
   @doc false
-  @spec eval_preview(
+  @spec eval_details(
           %{:details_mfa => {module(), atom(), list()}}
           | list(%{:details_mfa => {module(), atom(), list()}})
         ) :: map()

--- a/lib/swoosh/gallery.ex
+++ b/lib/swoosh/gallery.ex
@@ -187,9 +187,13 @@ defmodule Swoosh.Gallery do
     end
   end
 
-  # Evaluates a preview. It loads the results of email_mfa into the email property.
+  # Evaluates a preview. It loads the results of email_mfa and preview_details into the email
+  # and preview_details properties respectively.
   @doc false
-  @spec eval_preview(%{:email_mfa => {module(), atom(), list()}}) :: map()
+  @spec eval_preview(%{
+          :email_mfa => {module(), atom(), list()},
+          :details_mfa => {module(), atom(), list()}
+        }) :: map()
   def eval_preview(%{email: _email} = preview), do: preview
 
   def eval_preview(preview) do
@@ -202,6 +206,13 @@ defmodule Swoosh.Gallery do
     Map.put(preview, :email, apply(module, fun, opts))
   end
 
+  # Evaluates preview details. It loads the results of preview_details into the
+  # preview_details property.
+  @doc false
+  @spec eval_preview(
+          %{:details_mfa => {module(), atom(), list()}}
+          | list(%{:details_mfa => {module(), atom(), list()}})
+        ) :: map()
   def eval_details(%{preview_details: _details} = preview), do: preview
 
   def eval_details(%{details_mfa: {module, fun, opts}} = preview) do
@@ -216,7 +227,7 @@ defmodule Swoosh.Gallery do
 
   # Evaluates a preview and reads the attachment at a given index position.
   @doc false
-  @spec read_email_attachment_at(%{email_mfa: {atom, atom, list}}, integer()) ::
+  @spec read_email_attachment_at(%{email_mfa: {module, atom, list}}, integer()) ::
           {:error, :invalid_attachment | :not_found}
           | {:ok, %{content_type: String.t(), data: any}}
   def read_email_attachment_at(preview, index) do

--- a/lib/swoosh/gallery/layout.ex
+++ b/lib/swoosh/gallery/layout.ex
@@ -5,6 +5,7 @@ defmodule Swoosh.Gallery.Layout do
   """
 
   alias Swoosh.Email.Render
+  alias Swoosh.Gallery
   require EEx
 
   @external_resource index_file = Path.join([__DIR__, "templates", "index.html.eex"])
@@ -26,12 +27,14 @@ defmodule Swoosh.Gallery.Layout do
   """
   @spec render(atom, keyword) :: binary
   def render(gallery, assigns \\ []) do
+    previews = Gallery.eval_details(gallery.previews)
+
     ungrouped_previews =
-      gallery.previews
+      previews
       |> ungrouped_previews()
       |> sort_by_title()
 
-    groups = grouped_previews(gallery.groups, gallery.previews)
+    groups = grouped_previews(gallery.groups, previews)
 
     assigns
     |> Keyword.put(:ungrouped_previews, ungrouped_previews)

--- a/lib/swoosh/gallery/layout.ex
+++ b/lib/swoosh/gallery/layout.ex
@@ -5,7 +5,6 @@ defmodule Swoosh.Gallery.Layout do
   """
 
   alias Swoosh.Email.Render
-  alias Swoosh.Gallery
   require EEx
 
   @external_resource index_file = Path.join([__DIR__, "templates", "index.html.eex"])
@@ -27,14 +26,12 @@ defmodule Swoosh.Gallery.Layout do
   """
   @spec render(atom, keyword) :: binary
   def render(gallery, assigns \\ []) do
-    previews = Gallery.eval_details(gallery.previews)
-
     ungrouped_previews =
-      previews
+      gallery.previews
       |> ungrouped_previews()
       |> sort_by_title()
 
-    groups = grouped_previews(gallery.groups, previews)
+    groups = grouped_previews(gallery.groups, gallery.previews)
 
     assigns
     |> Keyword.put(:ungrouped_previews, ungrouped_previews)

--- a/lib/swoosh/gallery/plug.ex
+++ b/lib/swoosh/gallery/plug.ex
@@ -1,7 +1,7 @@
 defmodule Swoosh.Gallery.Plug do
   @moduledoc """
   Plug to mount a `Swoosh.Gallery` into an existing Phoenix/Plug application. Gallery themselves
-  will forward `init/1` and `call/2` to this dmoule, so users don't need to use it directly.
+  will forward `init/1` and `call/2` to this module, so users don't need to use it directly.
 
   ## Examples
 

--- a/test/mix/tasks/swoosh.gallery.html_test.exs
+++ b/test/mix/tasks/swoosh.gallery.html_test.exs
@@ -20,14 +20,14 @@ defmodule Mix.Tasks.Swoosh.Gallery.HtmlTest do
     assert File.dir?(tmp_dir)
 
     assert sorted_ls!(tmp_dir) == [
+             "auth.reset_password",
+             "auth.reset_password.html",
              "index.html",
-             "reset_password",
-             "reset_password.html",
              "welcome",
              "welcome.html"
            ]
 
-    assert sorted_ls!("#{tmp_dir}/reset_password") == ["preview.html"]
+    assert sorted_ls!("#{tmp_dir}/auth.reset_password") == ["preview.html"]
     assert sorted_ls!("#{tmp_dir}/welcome") == ["attachments", "preview.html"]
     assert sorted_ls!("#{tmp_dir}/welcome/attachments") == ["0"]
     assert sorted_ls!("#{tmp_dir}/welcome/attachments/0") == ["my_file.txt"]
@@ -44,7 +44,7 @@ defmodule Mix.Tasks.Swoosh.Gallery.HtmlTest do
     test "has links to the previews", %{tmp_dir: tmp_dir} do
       run_task(Support.Gallery, tmp_dir)
       contents = File.read!("#{tmp_dir}/index.html")
-      assert contents =~ "a href=\"./reset_password.html\""
+      assert contents =~ "a href=\"./auth.reset_password.html\""
       assert contents =~ "a href=\"./welcome.html\""
     end
 
@@ -58,7 +58,7 @@ defmodule Mix.Tasks.Swoosh.Gallery.HtmlTest do
 
     test "accessing a preview shows the email as text", %{tmp_dir: tmp_dir} do
       run_task(Support.Gallery, tmp_dir)
-      contents = File.read!("#{tmp_dir}/reset_password.html")
+      contents = File.read!("#{tmp_dir}/auth.reset_password.html")
       assert contents =~ "Reset Password"
       assert contents =~ "Sends instructions on how to reset password"
       assert contents =~ "passwords: yes"
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.Swoosh.Gallery.HtmlTest do
 
     test "accessing a preview.html shows the email as html", %{tmp_dir: tmp_dir} do
       run_task(Support.Gallery, tmp_dir)
-      contents = File.read!("#{tmp_dir}/reset_password/preview.html")
+      contents = File.read!("#{tmp_dir}/auth.reset_password/preview.html")
 
       assert contents ==
                "Please, reset your password <a href=\"http://reset.pw\">here</a>."

--- a/test/support/gallery.ex
+++ b/test/support/gallery.ex
@@ -2,5 +2,8 @@ defmodule Support.Gallery do
   use Swoosh.Gallery
 
   preview("/welcome", Support.Emails.WelcomeEmail)
-  preview("/reset_password", Support.Emails.ResetPasswordEmail)
+
+  group "/auth", title: "Auth" do
+    preview("/reset_password", Support.Emails.ResetPasswordEmail)
+  end
 end

--- a/test/swoosh/gallery_test.exs
+++ b/test/swoosh/gallery_test.exs
@@ -8,22 +8,33 @@ defmodule Swoosh.GalleryTest do
 
   describe "previews/0" do
     test "returns the list of previews" do
-      assert previews = Support.Gallery.previews()
+      assert previews = Support.Gallery.get()
 
-      assert [
-               %{
-                 details_mfa: {Support.Emails.ResetPasswordEmail, :preview_details, []},
-                 path: "reset_password",
-                 email_mfa: {Support.Emails.ResetPasswordEmail, :preview, []},
-                 group: nil
-               },
-               %{
-                 details_mfa: {Support.Emails.WelcomeEmail, :preview_details, []},
-                 path: "welcome",
-                 email_mfa: {Support.Emails.WelcomeEmail, :preview, []},
-                 group: nil
-               }
-             ] == previews
+      assert %{
+               previews: [
+                 %{
+                   preview_details: %{
+                     description: "Sends instructions on how to reset password",
+                     tags: [passwords: "yes"],
+                     title: "Reset Password"
+                   },
+                   path: "auth.reset_password",
+                   email_mfa: {Support.Emails.ResetPasswordEmail, :preview, []},
+                   group: "auth"
+                 },
+                 %{
+                   preview_details: %{
+                     description: "Sends a warm welcome to the user",
+                     tags: [attachments: "yes"],
+                     title: "Welcome"
+                   },
+                   path: "welcome",
+                   email_mfa: {Support.Emails.WelcomeEmail, :preview, []},
+                   group: nil
+                 }
+               ],
+               groups: [%{path: "auth", title: "Auth"}]
+             } = previews
     end
   end
 
@@ -38,7 +49,7 @@ defmodule Swoosh.GalleryTest do
     test "has links to the previews" do
       response = Router.call(conn(:get, "/gallery"), [])
       assert response.status == 200
-      assert response.resp_body =~ "a href=\"/gallery/reset_password\""
+      assert response.resp_body =~ "a href=\"/gallery/auth.reset_password\""
       assert response.resp_body =~ "a href=\"/gallery/welcome\""
     end
 
@@ -51,7 +62,7 @@ defmodule Swoosh.GalleryTest do
     end
 
     test "accessing a preview shows the email as text" do
-      response = Router.call(conn(:get, "/gallery/reset_password"), [])
+      response = Router.call(conn(:get, "/gallery/auth.reset_password"), [])
       assert response.status == 200
       assert response.resp_body =~ "Reset Password"
       assert response.resp_body =~ "Sends instructions on how to reset password"
@@ -60,7 +71,7 @@ defmodule Swoosh.GalleryTest do
     end
 
     test "accessing a preview.html shows the email as html" do
-      response = Router.call(conn(:get, "/gallery/reset_password/preview.html"), [])
+      response = Router.call(conn(:get, "/gallery/auth.reset_password/preview.html"), [])
       assert response.status == 200
 
       assert response.resp_body ==

--- a/test/swoosh/gallery_test.exs
+++ b/test/swoosh/gallery_test.exs
@@ -12,21 +12,13 @@ defmodule Swoosh.GalleryTest do
 
       assert [
                %{
-                 preview_details: %{
-                   description: "Sends instructions on how to reset password",
-                   tags: [passwords: "yes"],
-                   title: "Reset Password"
-                 },
+                 details_mfa: {Support.Emails.ResetPasswordEmail, :preview_details, []},
                  path: "reset_password",
                  email_mfa: {Support.Emails.ResetPasswordEmail, :preview, []},
                  group: nil
                },
                %{
-                 preview_details: %{
-                   description: "Sends a warm welcome to the user",
-                   tags: [attachments: "yes"],
-                   title: "Welcome"
-                 },
+                 details_mfa: {Support.Emails.WelcomeEmail, :preview_details, []},
                  path: "welcome",
                  email_mfa: {Support.Emails.WelcomeEmail, :preview, []},
                  group: nil


### PR DESCRIPTION
Currently if we change the preview file without changing the Gallery, it won't be recompiled. This adds the preview as compile-time dependency of the Gallery. 

Thanks to @hauptbenutzer for the suggestion!