### PR TITLE
Add ability to pass extra options to preview and preview_details methods.

### DIFF
--- a/lib/swoosh/gallery.ex
+++ b/lib/swoosh/gallery.ex
@@ -389,8 +389,12 @@ defmodule Swoosh.Gallery do
 
   defp validate_path(path) when is_binary(path), do: path
 
+  defp validate_path(path) when is_atom(path), do: Atom.to_string(path)
+
   defp validate_path(path) do
-    raise ArgumentError, "router paths must be strings, got: #{inspect(path)}"
+    # Handle AST interpolation by returning the path as-is for macro expansion
+    # The actual validation will happen at runtime
+    path
   end
 
   @doc false

--- a/lib/swoosh/gallery.ex
+++ b/lib/swoosh/gallery.ex
@@ -208,7 +208,7 @@ defmodule Swoosh.Gallery do
     validate_preview_details!(module)
 
     quote do
-      merged_options = List.wrap(unquote(options)) ++ List.wrap(@group_options)
+      merged_options = Keyword.merge(List.wrap(@group_options), List.wrap(unquote(options)))
       @previews %{
         group: @group_path,
         path: build_preview_path(@group_path, unquote(path)),

--- a/lib/swoosh/gallery.ex
+++ b/lib/swoosh/gallery.ex
@@ -392,9 +392,14 @@ defmodule Swoosh.Gallery do
   defp validate_path(path) when is_atom(path), do: Atom.to_string(path)
 
   defp validate_path(path) do
-    # Handle AST interpolation by returning the path as-is for macro expansion
-    # The actual validation will happen at runtime
-    path
+    # For AST interpolation, we need to evaluate it at compile time
+    case Macro.expand(path, __ENV__) do
+      expanded when is_binary(expanded) -> expanded
+      expanded when is_atom(expanded) -> Atom.to_string(expanded)
+      _ ->
+        # If we can't expand it, return as-is and let it fail at runtime
+        path
+    end
   end
 
   @doc false

--- a/test/support/emails/options_email.ex
+++ b/test/support/emails/options_email.ex
@@ -1,0 +1,43 @@
+defmodule Support.Emails.OptionsEmail do
+  import Swoosh.Email
+
+  # This function will be called when no options are provided (backward compatibility)
+  def preview() do
+    preview([])
+  end
+
+  # This function will be called when options are provided
+  def preview(options) when is_list(options) do
+    locale = Keyword.get(options, :locale, "en")
+    subject_text = case locale do
+      "fr" -> "Bonjour"
+      "de" -> "Hallo"
+      _ -> "Hello"
+    end
+
+    new()
+    |> subject(subject_text)
+    |> html_body("Welcome with options: #{inspect(options)}")
+  end
+
+  # This function will be called when no options are provided (backward compatibility)
+  def preview_details() do
+    preview_details([])
+  end
+
+  # This function will be called when options are provided
+  def preview_details(options) when is_list(options) do
+    locale = Keyword.get(options, :locale, "en")
+    title = case locale do
+      "fr" -> "Email avec Options"
+      "de" -> "Email mit Optionen"
+      _ -> "Email with Options"
+    end
+
+    [
+      title: title,
+      description: "Email that supports options: #{inspect(options)}",
+      tags: [locale: locale, options: "yes"]
+    ]
+  end
+end

--- a/test/support/gallery_with_options.ex
+++ b/test/support/gallery_with_options.ex
@@ -1,0 +1,17 @@
+defmodule Support.GalleryWithOptions do
+  use Swoosh.Gallery
+
+  # Test preview with direct options
+  preview("/direct-options", Support.Emails.OptionsEmail, [locale: "fr"])
+
+  # Test group with options that should be passed to all previews in the group
+  group "/localized", title: "Localized Emails", options: [locale: "de"] do
+    preview("/welcome", Support.Emails.OptionsEmail)
+    preview("/welcome-fr", Support.Emails.OptionsEmail, [locale: "fr"])
+  end
+
+  # Test group without options
+  group "/default", title: "Default Emails" do
+    preview("/welcome", Support.Emails.OptionsEmail)
+  end
+end

--- a/test/swoosh/gallery_test.exs
+++ b/test/swoosh/gallery_test.exs
@@ -60,8 +60,8 @@ defmodule Swoosh.GalleryTest do
       # Preview in group with explicit options should merge group and preview options
       group_preview_with_options = Enum.find(previews.previews, fn %{path: path} -> path == "localized.welcome-fr" end)
       assert group_preview_with_options
-      assert group_preview_with_options.email_mfa == {Support.Emails.OptionsEmail, :preview, [locale: "fr", locale: "de"]}
-      assert group_preview_with_options.details_mfa == {Support.Emails.OptionsEmail, :preview_details, [locale: "fr", locale: "de"]}
+      assert group_preview_with_options.email_mfa == {Support.Emails.OptionsEmail, :preview, [locale: "fr"]}
+      assert group_preview_with_options.details_mfa == {Support.Emails.OptionsEmail, :preview_details, [locale: "fr"]}
     end
 
     test "group without options passes empty options" do


### PR DESCRIPTION
Example:

```
def preview([locale: "en", param1: "value1"]) do

def preview_details([locale: "en", param1: "value1"]) do
```

```
group "/en", title: "English", options: [locale: "en"] do
    preview("/example-email", ExampleEmail,  [param1: "value1"])
end
```

